### PR TITLE
Updating Figure caption styling

### DIFF
--- a/_sass/my-inline.scss
+++ b/_sass/my-inline.scss
@@ -1,1 +1,12 @@
 // Includes inline theme overrides
+
+/* Custom Image Styles */
+.content figure img {
+  margin-bottom: .25rem;
+}
+
+figcaption {
+  margin-bottom: 1rem;
+  color: #898c8f;
+  font-size: .75rem;
+}


### PR DESCRIPTION
This PR fixes #32.

This PR adds some styling fixes for figure captions that make the captions actually look more like captions compared to normal paragraph text.  The parent theme did not have figure caption styling accounted for, so needed to add a couple of styling rules to accomplish the task.

## Screenshot of newly styled captions

Below screenshot is an example of how the newly styled captions look (used the same color and font size as mytlynch FYI...)

<kbd>
<img width="1146" alt="screen shot 2018-03-27 at 10 21 18 pm" src="https://user-images.githubusercontent.com/2396774/38005284-1be0c2ee-320e-11e8-916b-9eedd2d62158.png">
</kbd>

## Idea for future issue consideration:

I noticed that there are quite a lot of graphs in the site so far with whitespace on the sides. Aesthetically speaking I wonder if it makes sense to have the option to pass in a `border` option to the image include so if it is set then to style the `<image>` with a border around it.  It might just be my personal preference, but also the issue states a goal of "more closely associating the caption with the image" so it made me think it might be easier to do that with some of the graph images if there were a border around it?  Just a thought, but a couple screen caps below to maybe illustrate as well:

### Screenshot of example graph image with newly styled caption without a border

<img width="1152" alt="screen shot 2018-03-27 at 10 20 13 pm" src="https://user-images.githubusercontent.com/2396774/38005496-d808dec0-320e-11e8-8cac-05e50f9da388.png">


### Screenshot of example graph image with newly styled caption with a border
<img width="1149" alt="screen shot 2018-03-27 at 10 19 47 pm" src="https://user-images.githubusercontent.com/2396774/38005500-dd85bd64-320e-11e8-9164-d7db6fb72395.png">
Notice in this 2nd screenshot you can kinda see better where the graph image ends and the text underneath looks more like a caption to me?
