### PR TITLE
Bugfix: Fix for Demo Videos not displaying properly

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -258,9 +258,9 @@ kramdown:
 compress_html:
   comments:            ["<!-- ", " -->"]
   clippings:           all
-  endings:             all
-  ignore:
-    envs:              [development]
+  endings:             ""
+ # ignore:
+ #   envs:              [development]
 
 sass:
   style:               compressed

--- a/_config.yml
+++ b/_config.yml
@@ -259,8 +259,6 @@ compress_html:
   comments:            ["<!-- ", " -->"]
   clippings:           all
   endings:             ""
- # ignore:
- #   envs:              [development]
 
 sass:
   style:               compressed


### PR DESCRIPTION
This issue fixes #44 

I _believe_ this is one solution for the terminal recording video not displaying when the blog post is initially loaded with a push state action.  

## TLDR; Summary

This code update modifies the HTML compression settings in the configuration file to:
1. remove the HTML compression from removing certain tags that don't _require_ closing tags, and 
2. remove the option to _ONLY_ compress in production builds (I just commented out ignore development environment so we can still pretty easily de-compress if desired?)

I was not able to reproduce the issue locally and when looking at the page's source, I saw it wasn't compressed on my local dev environment.  When I activate compression in my development environment I was able to reproduce the issue, and could see in the page source that the browser was struggling to understand/render the `<script>` tag calling the "video" when coming from a push state event.  When making sure the compression configurations enforced all elements to have closing tags, the problem was remedied for me locally.

## More rambling explanation if interested

As noted, it appears as though the videos do not load when clicking the blog post link from the index page.  However, while on the blog post page, if you refresh the page, they load just fine.  My original theory was the theme's push state is causing this behavior because it only presented when the blog post was being loaded by push state as opposed to loading the whole DOM from scratch.

However, as stated in the TLDR; explanation, the issue was not occurring for me locally, I suppose due to the HTML compression settings.  So, when the compressed HTML is loaded via push state without certain close tags included, I just don't think the browser can render this scenario properly.  

That said, locally, if I disable push state but leave the compression settings to remove optional closing tags, then this also remedied the issue for me locally.  So, if push state presents other inconsistent issues like this, especially when it comes to some of the 3rd party references (asciinema.org, GA, Disqus, etc.) then we still may want to look at disabling this.  The push state does have slightly fancier page transitions, and has some merit for faster page speeds, etc.  I'm not opposed to disabling it though if it compromises page content consistency like you mentioned.

So, I'd consider this warning #1 for push state.  If we observe a warning #2, then maybe we go ahead and disable push state?  The page still has some loading animations, but not quite as fancy with push state.

## Final note on the videos
As you are aware the video embeds are being loaded with a js script that inserts an iframe with a custom player.  According to their docs there is _some_ customization that can be done, however, testing on a mobile device I did notice and realize this isn't responsive at all.  Not sure if that matters, but if so, may want to research other options for the video or see if there is anyway to make this responsive?  Just wanted to point it out in case it matters though...

