### PR TITLE
Adding a development build script

### DIFF
--- a/script/_serve_dev.sh
+++ b/script/_serve_dev.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# terminate the script if any command fails
+set -e
+
+# Start jekyll server
+bundle exec jekyll serve --watch


### PR DESCRIPTION
This PR fixes #39 .

This is a simple PR that ports over the `_serve_dev.sh` script almost identically from mtlynch.io ([https://github.com/mtlynch/mtlynch.io/blob/master/script/_serve_dev.sh](https://github.com/mtlynch/mtlynch.io/blob/master/script/_serve_dev.sh)).  On this site, we currently do not have any custom js to build so we don't have an npm task and we don't need a `_config_dev.yml` config right now at least so simplified the `jekyll serve` command.  It is good to have this in place in case additional commands and flags are necessary in the future though.

