### PR TITLE
Switching Travis language to Python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ sudo: required
 services:
   - docker
 dist: trusty
+language: python
+python:
+  - "2.7"
 script: _tests/docker_build
 deploy:
   provider: firebase


### PR DESCRIPTION
The actual language doesn't matter because everything is happening in a Docker container, so we just use whatever is fastest.