### PR TITLE
Switching back to local Dockerfile

### DIFF
--- a/_tests/docker_build
+++ b/_tests/docker_build
@@ -5,8 +5,11 @@ set -e
 # Echo commands to console.
 set -x
 
-IMAGE_NAME="mtlynch/jekyll"
+IMAGE_VERSION=$(git rev-parse HEAD)
+IMAGE_NAME="mtlynch-io:${IMAGE_VERSION}"
 CONTAINER_NAME="spaceduck-io-container"
+
+docker build -t "$IMAGE_NAME" _tests/
 
 docker run --tty --detach --volume "${PWD}:/app" --name "$CONTAINER_NAME" "$IMAGE_NAME"
 


### PR DESCRIPTION
The pre-built image for some reason causes opengraph metadata to break