### PR TITLE
Feature: Remove Tags from Index View

### DIFF
--- a/_includes/post.html
+++ b/_includes/post.html
@@ -1,0 +1,45 @@
+{% assign post = include.post %}
+{% assign link_title = include.link_title %}
+
+<article id="post{{ post.id | replace:'/','-' }}" class="page post{% if link_title %} mb6{% endif %}" role="article">
+  <header>
+    <h1 class="post-title">
+      {% if link_title %}<a href="{{ post.url | relative_url }}" class="flip-title">{% endif %}
+        {{ post.title }}
+      {% if link_title %}</a>{% endif %}
+    </h1>
+
+    <p class="post-date heading">
+      {% assign post_format = site.data.strings.date_formats.post | default:"%d %b %Y" %}
+      <time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date:post_format }}</time>
+
+      {% comment %}
+      <!-- Only display tags/categories on blog posts -->
+      {% endcomment %}
+      {% if page.layout == "post" %}
+        {% assign category_start     = site.data.strings.category_start     | default:"in " %}
+        {% assign tag_start          = site.data.strings.tag_start          | default:"on " %}
+        {% assign category_separator = site.data.strings.category_separator | default:" / " %}
+        {% assign tag_separator      = site.data.strings.tag_separator      | default:", "  %}
+        {% include tag-list.html tags=post.categories meta=site.featured_categories start_with=category_start separator=category_separator %}
+        {% include tag-list.html tags=post.tags meta=site.featured_tags start_with=tag_start separator=tag_separator %}
+      {% endif %}
+
+    </p>
+
+    {% include message.html text=post.description hide=page.hide_description %}
+  </header>
+
+  {% unless include.excerpt %}
+    {{ post.content }}
+  {% else %}
+    {{ post.excerpt }}
+    {% capture post_title %}<a class="heading flip-title" href="{{ post.url | relative_url }}">{{ post.title }}</a>{% endcapture %}
+    {% assign text = site.data.strings.continue_reading | default:"Continue reading <!--post_title-->" %}
+    <footer>
+      <p class="read-more">
+        {{ text | replace:"<!--post_title-->", post_title }}
+      </p>
+    </footer>
+  {% endunless %}
+</article>


### PR DESCRIPTION
This PR fixes #34.

This update removes a blog post's associated tags from the blog index view.

In order to accomplish this, we need to customize the parent theme's `_includes/post.html` file so future upgrades of the theme will need to take this customization into account.  The file was cloned from the parent theme and then [customized with an if logic statement to see if the post is the index or actual blog post](https://github.com/mtlynch/spaceduck/compare/master...shredtechular:issue-34?expand=1#diff-5b266094d20f797a6b8fc73a7b898abcR16).

## Screenshots of update

### Desktop view of blog index without the tags
<img width="1148" alt="screen shot 2018-04-07 at 10 24 04 am" src="https://user-images.githubusercontent.com/2396774/38456035-f1f2f022-3a4d-11e8-9f2c-f324403f67ba.png">

### Desktop view of blog post still containing the tags on the post
<img width="1180" alt="screen shot 2018-04-07 at 10 24 46 am" src="https://user-images.githubusercontent.com/2396774/38456042-ffae72f4-3a4d-11e8-9119-e762d6f165b3.png">
