### PR TITLE
Feature: Remove icon from external links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -108,7 +108,7 @@ hydejack:
   no_google_fonts:     false
 
   # Set to `true` if you don't want to show an icon indicating external links
-  no_mark_external:    false
+  no_mark_external:    true
 
   # Set to `true` if third party plugins fail to work with dynamically loaded pages
   no_push_state:       false


### PR DESCRIPTION
This PR fixes #33 .

This PR includes a configuration change that removes the arrow icon from external links throughout the site.

## Screenshots of configuration change

### Before
<kbd>
<img width="680" alt="screen shot 2018-04-07 at 10 31 26 am" src="https://user-images.githubusercontent.com/2396774/38456143-fccaa44e-3a4e-11e8-82f7-8ac46da246a1.png">
</kbd>


### After
<kbd>
<img width="703" alt="screen shot 2018-04-07 at 10 31 47 am" src="https://user-images.githubusercontent.com/2396774/38456145-00fd377a-3a4f-11e8-9e37-2d44d9b5d154.png">
</kbd>
