### PR TITLE
Feature: Removing post excerpts from index pg

### DIFF
--- a/_includes/post.html
+++ b/_includes/post.html
@@ -32,14 +32,5 @@
 
   {% unless include.excerpt %}
     {{ post.content }}
-  {% else %}
-    {{ post.excerpt }}
-    {% capture post_title %}<a class="heading flip-title" href="{{ post.url | relative_url }}">{{ post.title }}</a>{% endcapture %}
-    {% assign text = site.data.strings.continue_reading | default:"Continue reading <!--post_title-->" %}
-    <footer>
-      <p class="read-more">
-        {{ text | replace:"<!--post_title-->", post_title }}
-      </p>
-    </footer>
   {% endunless %}
 </article>


### PR DESCRIPTION
This PR fixes #35.

This update removes the blog post's excerpt and "Continue reading" link from the site's index page.  This is a simple customization to the `post` include and removes the code that renders those 2 items.

## Screenshots of update

### Before the update
<img width="1160" alt="screen shot 2018-04-07 at 1 51 53 pm" src="https://user-images.githubusercontent.com/2396774/38458314-f076da2a-3a6a-11e8-9993-e16b7c3281ad.png">


### After the update is applied
<img width="1146" alt="screen shot 2018-04-07 at 1 52 07 pm" src="https://user-images.githubusercontent.com/2396774/38458316-f47d582e-3a6a-11e8-8293-39e73c7a4246.png">
