### PR TITLE
Feature: Adding border option to responsive image template

### DIFF
--- a/_includes/image.html
+++ b/_includes/image.html
@@ -26,6 +26,8 @@
     figure.  If a figure tag is to be used, then the class will apply to the
     figure tag.  If a figure tag is not being used, then the class will apply
     to the image tag.
+  @param {boolean} "border" - Optional, default is false. If img should have a
+    surrounding 1px border.
 -->
 {% endcomment %}
 
@@ -53,4 +55,5 @@
     media_rendition: {{ media_rendition }}
     max_width: {{ include.max_width }}
     class: {{ include.class }}
+    border: {{ include.border }}
 {% endresponsive_image_block %}

--- a/_includes/responsive-image.html
+++ b/_includes/responsive-image.html
@@ -26,6 +26,8 @@
     figure.  If a figure tag is to be used, then the class will apply to the
     figure tag.  If a figure tag is not being used, then the class will apply
     to the image tag.
+  @param {boolean} "border" - Optional, default is false. If img should have a
+    surrounding 1px border.
 -->
 {% endcomment %}
 
@@ -60,6 +62,14 @@
   {% assign img_url = site.baseurl | append: "/" | append: original.path %}
 {% endif %}
 
+{% comment %}
+<!-- determine if image should have border -->
+{% endcomment %}
+{% assign border_class = "" %}
+{% if border %}
+  {% assign border_class = "border" %}
+{% endif %}
+
 {% if fig_caption %}
 <figure class="{{ class }}">
   {% assign class = "" %}
@@ -67,10 +77,10 @@
 
 {% if img_url %}
 <a href="{{ img_url }}" class="no-push-state">
-  <img src="/{{ path }}" alt="{{ alt }}" srcset="{{ srcset | strip_newlines }}" sizes="{{ sizes }}" class="{{ class }}"{% if max_width %} style="max-width:{{ sizes }}"{% endif %}>
+  <img src="/{{ path }}" alt="{{ alt }}" srcset="{{ srcset | strip_newlines }}" sizes="{{ sizes }}" class="{{ class }} {{ border_class }}"{% if max_width %} style="max-width:{{ sizes }}"{% endif %}>
 </a>
 {% else %}
-<img src="/{{ path }}" alt="{{ alt }}" srcset="{{ srcset | strip_newlines }}" sizes="{{ sizes }}" class="{{ class }}"{% if max_width %} style="max-width:{{ sizes }}"{% endif %}>
+<img src="/{{ path }}" alt="{{ alt }}" srcset="{{ srcset | strip_newlines }}" sizes="{{ sizes }}" class="{{ class }} {{ border_class }}"{% if max_width %} style="max-width:{{ sizes }}"{% endif %}>
 {% endif %}
 
 {% if fig_caption %}

--- a/_posts/2018-02-16-sia-metrics-collector.md
+++ b/_posts/2018-02-16-sia-metrics-collector.md
@@ -21,13 +21,13 @@ Graphs and detailed metrics make it easier to understand Sia's behavior. If all 
 
 I wanted to see a graph of changes over time, like this one:
 
-{% include image.html file="data-uploaded-dev.png" img_link=true alt="Data uploaded over time" %}
+{% include image.html file="data-uploaded-dev.png" img_link=true alt="Data uploaded over time" border="true" %}
 
 The above graph is from a real trial run of the load test using a 500 SC wallet. You see that Sia uploads data steadily for the first eight hours, then slows down until finally flatlining at ~0.3 TiB of file data uploaded, or ~1 TiB of contract usage (3x file data because of Sia's 3x redundancy).
 
 This is clearer in  the graph of Sia's upload bandwidth:
 
-{% include image.html file="upload-bandwidth-dev.png" alt="Upload bandwidth over time" img_link=true %}
+{% include image.html file="upload-bandwidth-dev.png" alt="Upload bandwidth over time" img_link=true border="true" %}
 
 For eight hours, Sia maintained an impressively high upload bandwidth of ~250 Mbps, but rapidly declined to near zero over the next few hours.
 
@@ -43,11 +43,11 @@ As Sia purchases more contracts, it moves money from your wallet into active con
 
 Here's a graph that shows this on a real test with 5000 SC. The sum of wallet balance and contract spending remains 5000 SC throughout:
 
-{% include image.html file="funds-balance-test1.png" alt="Renter spending over time" img_link="true" %}
+{% include image.html file="funds-balance-test1.png" alt="Renter spending over time" img_link="true" border="true" %}
 
 I tried the same test using a 500 SC wallet and saw drastically different results:
 
-{% include image.html file="funds-balance-dev.png" alt="Renter spending over time" img_link="true" %}
+{% include image.html file="funds-balance-dev.png" alt="Renter spending over time" img_link="true" border="true" %}
 
 My 500 SC wallet balance dwindled down to zero, but I only ended up with 333.33 SC in storage contracts. So where'd the last 166.67 SC go?
 
@@ -70,7 +70,7 @@ If you buy a 33.3 SC storage contract, ~5.5 SC is lost to contract fees. The rem
 
 Sia Metrics Collector tracks all of these metrics over time. Here's a graph of how those costs changed as my Sia node formed 50 contracts of 3.33 SC each, then began uploading data:
 
-{% include image.html file="renter-spending-dev.png" alt="Renter spending over time" img_link=true %}
+{% include image.html file="renter-spending-dev.png" alt="Renter spending over time" img_link=true border="true" %}
 
 You may notice something unexpected about storage spending (the red line). I expected it to strictly increase, but there are several instances around the four-hour mark where it decreases.
 
@@ -80,7 +80,7 @@ This would be like pumping gas for your car and watching your the gas meter go f
 
 The metrics revealed that Sia makes wasteful choices with contract spending. Take another look at the spending graph from above:
 
-{% include image.html file="renter-spending-dev.png" alt="Renter spending over time" image_link=true %}
+{% include image.html file="renter-spending-dev.png" alt="Renter spending over time" image_link=true border="true" %}
 
 I wondered why remaining renter funds (the green line) sometimes increased. That metric should strictly *decrease* as I upload data. Instead, it shows a sawtooth pattern, alternately increasing and decreasing for the first six hours. How could I be gaining funds by uploading data?
 

--- a/_posts/2018-03-15-load-test-1.md
+++ b/_posts/2018-03-15-load-test-1.md
@@ -110,7 +110,7 @@ In this test, efficiency was  five times lower than that, at 0.000000447%, meani
 
 **Sia's efficiency degraded over time**. The graph below shows a consistent pattern of efficiency rising slightly before taking a significant dip. Overall, efficiency decreased substantially as the test progressed.
 
-{% include image.html file="storage-efficiency.png" alt="Graph of storage efficiency over time" fig_caption="Sia 1.3.1 Load Test&#58; Worst-Case - Storage efficiency" img_link="true" %}
+{% include image.html file="storage-efficiency.png" alt="Graph of storage efficiency over time" fig_caption="Sia 1.3.1 Load Test&#58; Worst-Case - Storage efficiency" img_link="true" border="true" %}
 
 This pattern may be the result of bad hosts. If the test node's Sia hosts were constantly disappearing, this would drive efficiency down as Sia is forced to reupload data to new hosts. However, this would imply such a high rate of host churn that I'm skeptical this is the whole cause.
 
@@ -126,13 +126,13 @@ This pattern may be the result of bad hosts. If the test node's Sia hosts were c
 
 The graph below reveals this bug. The wallet and renter were in a closed system, so the total number of Siacoins between the two should not have changed until the contracts expired.
 
-{% include image.html file="funds-balance.png" alt="Graph of renter funds balance over time" fig_caption="Sia 1.3.1 Load Test&#58; Worst-case - Funds split between wallet balance and total contract spending" img_link="true" %}
+{% include image.html file="funds-balance.png" alt="Graph of renter funds balance over time" fig_caption="Sia 1.3.1 Load Test&#58; Worst-case - Funds split between wallet balance and total contract spending" img_link="true" border="true" %}
 
 In the first few hours, the wallet and contracts correctly maintain a constant sum of 5000 SC. Over time, money begins to disappear from the wallet without fully reappearing in renter contract spending.
 
 **Sia lost 69.3 SC due to premature contract renewal**. The graph below shows something interesting around the 400-hour mark. Until that point, Sia had 1,766.7 SC in wallet balance that it had not allocated to contracts. All of a sudden, it spent its entire remaining wallet balance on new contracts, including 69.3 SC in contract fees. This seems to be due to a bug that causes Sia to [renew contracts prematurely](https://github.com/NebulousLabs/Sia/issues/2866).
 
-{% include image.html file="renter-spending.png" alt="Graph of renter spending over time" fig_caption="Sia 1.3.1 Load Test&#58; Worst-case - Renter spending" img_link="true" %}
+{% include image.html file="renter-spending.png" alt="Graph of renter spending over time" fig_caption="Sia 1.3.1 Load Test&#58; Worst-case - Renter spending" img_link="true" border="true" %}
 
 **Sia lost money to poor contract management**. Sia also lost money due to [poor contract management](https://github.com/NebulousLabs/Sia/issues/2769), which I've reported previously. The purple line shows the amount remaining in Sia's storage contracts still available for upload, download, and storage. In theory, Sia shouldn't form new contracts until this line reaches near zero, but throughout the test, Sia purchased new contracts even with ~1000 SC left in unused renter spending.
 
@@ -142,15 +142,15 @@ The test uploaded 47.2 KiB of file data in 596.8 hours. That's equivalent to an 
 
 **Upload bandwidth slowed exponentially over time**. The graph of upload data shows that it got exponentially slower as the test progressed. I don't have enough data yet to know whether this is a function of time, data uploaded, or file count, but I should have a better picture in subsequent test cases.
 
-{% include image.html file="upload-bandwidth-file-data.png" alt="Graph of upload bandwidth over time" fig_caption="Sia 1.3.1 Load Test&#58; Worst-case - Upload bandwidth (File data)" img_link="true" %}
+{% include image.html file="upload-bandwidth-file-data.png" alt="Graph of upload bandwidth over time" fig_caption="Sia 1.3.1 Load Test&#58; Worst-case - Upload bandwidth (File data)" img_link="true" border="true" %}
 
 **Absolute upload bandwidth was bursty**. The absolute bandwidth graph shows a curve very similar to file data bandwidth, but with intermittent spikes.
 
-{% include image.html file="upload-bandwidth-absolute.png" alt="Graph of upload bandwidth over time" fig_caption="Sia 1.3.1 Load Test&#58; Worst-case - Upload bandwidth (Absolute)" img_link="true" %}
+{% include image.html file="upload-bandwidth-absolute.png" alt="Graph of upload bandwidth over time" fig_caption="Sia 1.3.1 Load Test&#58; Worst-case - Upload bandwidth (Absolute)" img_link="true" border="true" %}
 
 Some measurements reached as high as 600 Mbps, which I think is measurement error due to API latency effects (discussed below). I wondered if these spikes were entirely due to measurement error, but the graph of data uploaded corroborates these spikes:
 
-{% include image.html file="upload-data.png" alt="Graph of renter funds balance over time" fig_caption="Sia 1.3.1 Load Test&#58; Worst-case - Total contract size" img_link="true" %}
+{% include image.html file="upload-data.png" alt="Graph of renter funds balance over time" fig_caption="Sia 1.3.1 Load Test&#58; Worst-case - Total contract size" img_link="true" border="true" %}
 
 ## API latency
 
@@ -162,7 +162,7 @@ All the metrics shown in this report come from three Sia daemon APIs that [sia_m
 
 The API latency is the total amount of time required to call these three APIs in sequence:
 
-{% include image.html file="api-latency.png" alt="Graph of API latency over time" fig_caption="Sia 1.3.1 Load Test&#58; Worst-case - API Latency" img_link="true" %}
+{% include image.html file="api-latency.png" alt="Graph of API latency over time" fig_caption="Sia 1.3.1 Load Test&#58; Worst-case - API Latency" img_link="true" border="true" %}
 
 **API latency is very high**. Even at the beginning of the test, Sia generally took ~3 seconds to reply to all three API calls, which is very high given that it's communication between processes on the same system. By the end, latency had increased to over 5 minutes, which is *extremely* high for a REST API.
 
@@ -172,7 +172,7 @@ The API latency is the total amount of time required to call these three APIs in
 
 **Bandwidth bursts are correlated with bursts in API latency**. Interestingly, the graph shows several "bursts" of high latency. I thought at first that the high bandwidth measurements were simply a result of measurement artifacts caused by the high API latency, but the graphs of total data uploaded over time (above) seem to disprove this. Another possibility is that Sia prioritizes bandwidth above all else, so it responds more slowly to API requests because the uploader is monopolizing RAM and CPU.
 
-{% include image.html file="api-latency-vs-bandwidth.png" alt="Graph of API latency vs. bandwidth over time" fig_caption="Sia 1.3.1 Load Test&#58; Worst-case - API Latency vs. Bandwidth (Absolute)" img_link="true" %}
+{% include image.html file="api-latency-vs-bandwidth.png" alt="Graph of API latency vs. bandwidth over time" fig_caption="Sia 1.3.1 Load Test&#58; Worst-case - API Latency vs. Bandwidth (Absolute)" img_link="true" border="true" %}
 
 ## Raw data
 

--- a/_posts/2018-03-23-load-test-2.md
+++ b/_posts/2018-03-23-load-test-2.md
@@ -120,7 +120,7 @@ Here are some more details about the files:
 
 Of the 2,626 files, 10 were small metadata files (`Thumbs.db` and such) that slipped in. The vast majority of files were well above Sia's 40 MiB chunk size.
 
-{% include image.html file="file-size-histogram.png" alt="File size histogram" fig_caption="Sia 1.3.1 Load Test&#58; Real data - File size histogram" img_link="true" %}
+{% include image.html file="file-size-histogram.png" alt="File size histogram" fig_caption="Sia 1.3.1 Load Test&#58; Real data - File size histogram" img_link="true" border="true" %}
 
 ## Storage efficiency
 
@@ -128,7 +128,7 @@ To measure how well Sia stores data, I created the metric of "storage efficiency
 
 On traditional cloud storage providers, efficiency is 100% because you pay for exactly the size of your files. On Sia, the best possible efficiency is 33.3% because Sia uploads every byte of file data at least three times for redundancy. Other factors can degrade efficiency, such as inefficient repackaging of files or unreliable hosts.
 
-{% include image.html file="storage-efficiency.png" alt="Graph of storage efficiency over time" fig_caption="Sia 1.3.1 Load Test&#58; Real Data - Storage efficiency" img_link="true" %}
+{% include image.html file="storage-efficiency.png" alt="Graph of storage efficiency over time" fig_caption="Sia 1.3.1 Load Test&#58; Real Data - Storage efficiency" img_link="true" border="true" %}
 
 There's a lot in the graph that's unexpected to me, so let me start with the part I can explain.
 
@@ -142,17 +142,17 @@ Then Sia got to the raw ISO files, which are probably the best match for Sia's f
 
 The most striking part of the efficiency graph was between the 100- and 150-hour marks, where efficiency took a huge plunge. The graph below zooms in on exactly this portion of the timeline:
 
-{% include image.html file="storage-efficiency-zoomed.png" alt="Graph of storage efficiency over time" fig_caption="Sia 1.3.1 Load Test&#58; Real Data - Storage efficiency - hours 100 to 150" img_link="true" %}
+{% include image.html file="storage-efficiency-zoomed.png" alt="Graph of storage efficiency over time" fig_caption="Sia 1.3.1 Load Test&#58; Real Data - Storage efficiency - hours 100 to 150" img_link="true" border="true" %}
 
 For 17 hours, efficiency goes straight down. This suggests that Sia exclusively repaired existing data instead of uploading new files.
 
 The file data bandwidth graph confirms this, as upload bandwidth dropped to zero for almost the entire period:
 
-{% include image.html file="upload-bandwidth-file-data-zoomed.png" alt="Graph of upload bandwidth over time" fig_caption="Sia 1.3.1 Load Test&#58; Real Data - Upload bandwidth (file data) - hours 100 to 150" img_link="true" %}
+{% include image.html file="upload-bandwidth-file-data-zoomed.png" alt="Graph of upload bandwidth over time" fig_caption="Sia 1.3.1 Load Test&#58; Real Data - Upload bandwidth (file data) - hours 100 to 150" img_link="true" border="true" %}
 
 Interestingly, absolute bandwidth did not change significantly during this time:
 
-{% include image.html file="upload-bandwidth-absolute-zoomed.png" alt="Graph of upload bandwidth over time" fig_caption="Sia 1.3.1 Load Test&#58; Real Data - Upload bandwidth (absolute) - hours 100 to 150" img_link="true" %}
+{% include image.html file="upload-bandwidth-absolute-zoomed.png" alt="Graph of upload bandwidth over time" fig_caption="Sia 1.3.1 Load Test&#58; Real Data - Upload bandwidth (absolute) - hours 100 to 150" img_link="true" border="true" %}
 
 This means that Sia stopped uploading new data and instead just increased redundancy of already uploaded data. But why?
 
@@ -178,7 +178,7 @@ Everything after hour 125 baffles me. Efficiency just gets lower and lower, whic
 
 ## Cost
 
-{% include image.html file="renter-spending.png" alt="Graph of renter spending over time" fig_caption="Sia 1.3.1 Load Test&#58; Real Data - Renter spending" img_link="true" %}
+{% include image.html file="renter-spending.png" alt="Graph of renter spending over time" fig_caption="Sia 1.3.1 Load Test&#58; Real Data - Renter spending" img_link="true" border="true" %}
 
 The regularity is striking in this graph. Unlike my previous Sia experiments that showed unexpected spikes or drops, this graph shows clear, intuitive patterns.
 
@@ -186,7 +186,7 @@ The regularity is striking in this graph. Unlike my previous Sia experiments tha
 
 Sia's standard estimate of storage costs has been $2 per TB/mo for as long as I can remember. It was on the front page of [their website](https://web.archive.org/web/20180128225909/https://sia.tech/) until January 2018.
 
-{% include image.html file="website-estimate.png" alt="Price estimate on Sia website" fig_caption="Storage price estimate on Sia website captured 2018-01-28." img_link="true" %}
+{% include image.html file="website-estimate.png" alt="Price estimate on Sia website" fig_caption="Storage price estimate on Sia website captured 2018-01-28." img_link="true" border="true" %}
 
 Sia quoted a figure of "$2-3 per TB" on Twitter as recently as [three weeks ago](https://twitter.com/SiaTechHQ/status/968910948953153537).
 
@@ -217,7 +217,7 @@ I've replicated [bug #2772](https://github.com/NebulousLabs/Sia/issues/2772) in 
 
 As Sia spends money from the 5000 SC allocated for this test, the money should move from the Sia wallet into Sia contracts, maintaining a constant sum of 5000 SC. Instead, Sia spent the full 5000 SC from its wallet but only ended up with 2,866.7 SC in contract value, leaving 2,133.3 SC missing.
 
-{% include image.html file="funds-balance.png" alt="Graph of renter funds balance over time" fig_caption="Sia 1.3.1 Load Test&#58; Worst-case - Funds split between wallet balance and total contract spending" img_link="true" %}
+{% include image.html file="funds-balance.png" alt="Graph of renter funds balance over time" fig_caption="Sia 1.3.1 Load Test&#58; Worst-case - Funds split between wallet balance and total contract spending" img_link="true" border="true" %}
 
 In response to the previous load test report, Sia's lead developer, David Vorick, [speculated](https://www.reddit.com/r/siacoin/comments/84nh8t/sia_load_test_result_1_worstcase_scenario/dvr9ur8/?st=jf19mq0o&sh=912549ba) that Sia could be spending correctly but accounting incorrectly. In other words, it's possible that Sia actually used the missing 2,133.3 SC to purchase contracts, but the value of those contracts did not appear in Sia's self-reported metrics.
 
@@ -304,7 +304,7 @@ The test uploaded 4.3 TiB of file data in 231.7 hours. That's equivalent to an o
 
 **Bandwidth was strong for the first 2.5 TiB**.
 
-{% include image.html file="upload-bandwidth-file-data.png" alt="Graph of upload bandwidth over time" fig_caption="Sia 1.3.1 Load Test&#58; Real Data - Upload bandwidth (file data)" img_link="true" %}
+{% include image.html file="upload-bandwidth-file-data.png" alt="Graph of upload bandwidth over time" fig_caption="Sia 1.3.1 Load Test&#58; Real Data - Upload bandwidth (file data)" img_link="true" border="true" %}
 
 For the first 75 hours of the test (until about 2.5 TiB of file data uploaded), Sia's bandwidth hovered between 75 to 100 Mbps, which is very impressive. It's slower than traditional providers like Amazon S3 or Google Cloud Storage, but it's fast enough to support real backup scenarios. At a rate of 100 Mbps, you could upload 1 TiB of file data per day.
 
@@ -328,7 +328,7 @@ All the metrics shown in this report come from three Sia daemon APIs that [sia_m
 
 The API latency is the total amount of time required to call these three APIs in sequence:
 
-{% include image.html file="api-latency.png" alt="Graph of API latency over time" fig_caption="Sia 1.3.1 Load Test&#58; Real Data - API Latency" img_link="true" %}
+{% include image.html file="api-latency.png" alt="Graph of API latency over time" fig_caption="Sia 1.3.1 Load Test&#58; Real Data - API Latency" img_link="true" border="true" %}
 
 The latency graph is an interesting change from the [previous test case](https://blog.spaceduck.io/load-test-1/#api-latency). In that experiment, the API latency contained brief spikes in latency and many random outliers. This graph is much more regular and clustered. There are no sustained spikes, and there's almost a precise "floor" for each point on the graph where all the measurements cluster.
 
@@ -347,7 +347,7 @@ The latency increases matched increases in file count. Recall that I was uploadi
 
 The different file types vary widely in size, so the file count's rate of change varied through the test. Plotting the file count against the latency, it appears that the rate of increase in latency was tightly correlated with the rate of increase for file count:
 
-{% include image.html file="api-latency-annotated.png" alt="Graph of API latency vs. file count" fig_caption="Sia 1.3.1 Load Test&#58; Real Data - API Latency" img_link="true" %}
+{% include image.html file="api-latency-annotated.png" alt="Graph of API latency vs. file count" fig_caption="Sia 1.3.1 Load Test&#58; Real Data - API Latency" img_link="true" border="true" %}
 
 ## Raw data
 

--- a/_posts/2018-04-05-sia-blockchain-sync.md
+++ b/_posts/2018-04-05-sia-blockchain-sync.md
@@ -20,7 +20,7 @@ I was frustrated with how long the initial sync was taking so I decided to look 
 
 Every Siacoin, Siafund, smart contract, and storage proof transaction is stored on the Sia blockchain and in your local `consensus.db` file. Add all these transactions together and you're looking at over 8,000,000 transactions stored as of March 2018.
 
-{% include image.html file="total-transactions.png" alt="total transactions graph" fig_caption="Total historic Sia blockchain transactions &#40;Source&#58; SiaStats.info&#41;" img_link="true" %}
+{% include image.html file="total-transactions.png" alt="total transactions graph" fig_caption="Total historic Sia blockchain transactions &#40;Source&#58; SiaStats.info&#41;" img_link="true" border="true" %}
 
 When you perform the initial sync, Sia downloads every block (over 146,000 at the time of this writing) from its peers and adds them to the local `consensus.db` file. Before adding it to your `consensus.db` file Sia performs a variety of actions on every block. The workflow looks something like this:
 
@@ -35,7 +35,7 @@ Sia downloads blocks in batches of 10, but it needs to process and validate ever
 
 I was frustrated with how long the initial sync took, so I started to do some rough benchmarking and made some interesting discoveries.
 
-{% include image.html file="default-configuration-pie.png" alt="time-spent-on-each-task-pie-chart" fig_caption="Percent time spent on each task" img_link="true" %}
+{% include image.html file="default-configuration-pie.png" alt="time-spent-on-each-task-pie-chart" fig_caption="Percent time spent on each task" img_link="true" border="true" %}
 
 ## Downloading blocks
 
@@ -48,7 +48,7 @@ My benchmarking revealed that with default Sia settings it took an average of 16
 * Sia downloads in small batches
   * Sia downloads bocks in batches of 10. That means Sia requests blocks at least 14,600 times for a full blockchain sync. I believe Sia could request blocks in batches of 100, or even 1,000 and reduce some of the overhead from making so many requests.
 
-{% include image.html file="blockchain-size.png" alt="Sia blockchain size graph" fig_caption="Sia blockchain growth over time &#40;Source&#58; SiaStats.info&#41;" img_link="true" %}
+{% include image.html file="blockchain-size.png" alt="Sia blockchain size graph" fig_caption="Sia blockchain growth over time &#40;Source&#58; SiaStats.info&#41;" img_link="true" border="true" %}
 
 ## Validate every transaction in block
 

--- a/_posts/2018-04-12-load-test-3.md
+++ b/_posts/2018-04-12-load-test-3.md
@@ -118,7 +118,7 @@ To measure how well Sia stores data, I created the metric of "storage efficiency
 
 On traditional cloud storage providers, efficiency is 100% because you pay for exactly the size of your files. On Sia, the best possible efficiency is 33.3% because Sia uploads every byte of file data at least three times for redundancy. Other factors can degrade efficiency, such as inefficient repackaging of files or unreliable hosts.
 
-{% include image.html file="storage-efficiency.png" alt="Graph of storage efficiency over time" fig_caption="Sia 1.3.1 Load Test&#58; Real Data - Storage efficiency" img_link="true" %}
+{% include image.html file="storage-efficiency.png" alt="Graph of storage efficiency over time" fig_caption="Sia 1.3.1 Load Test&#58; Real Data - Storage efficiency" img_link="true" border="true" %}
 
 **Efficiency was stable at 33% for most of the test**.
 

--- a/_posts/2018-04-12-load-test-3.md
+++ b/_posts/2018-04-12-load-test-3.md
@@ -162,7 +162,7 @@ This is unexpected, given that this test optimized specifically for storage effi
 
 ## Cost
 
-{% include image.html file="renter-spending.png" alt="Graph of renter spending over time" fig_caption="Sia 1.3.1 Load Test&#58; Real Data - Renter spending" img_link="true" %}
+{% include image.html file="renter-spending.png" alt="Graph of renter spending over time" fig_caption="Sia 1.3.1 Load Test&#58; Real Data - Renter spending" img_link="true" border="true" %}
 
 **Cost per TB was $5.13**.
 
@@ -213,7 +213,7 @@ I've replicated [bug #2772](https://github.com/NebulousLabs/Sia/issues/2772) in 
 
 As Sia spends money from the 5,000 SC allocated for this test, the money should move from the Sia wallet into Sia contracts, maintaining a constant sum of 5,000 SC. The graph below shows that the funds start by totaling 5,000 SC but then gradually decrease as funds disappear.
 
-{% include image.html file="funds-balance.png" alt="Graph of renter funds balance over time" fig_caption="Sia 1.3.1 Load Test&#58; Worst-case - Funds split between wallet balance and total contract spending" img_link="true" %}
+{% include image.html file="funds-balance.png" alt="Graph of renter funds balance over time" fig_caption="Sia 1.3.1 Load Test&#58; Worst-case - Funds split between wallet balance and total contract spending" img_link="true" border="true" %}
 
 The twist in this case was that just after the system reboot, total funds *increased*. At the 249.0 hour mark, contract spending and wallet balance summed to 4,800 SC, leaving 200 SC missing.
 
@@ -227,7 +227,7 @@ The test uploaded 1.5 TiB of file data in 336.0 hours. That's equivalent to an o
 
 *Note: Bandwidth measurements in this test are non-rigorous due to the limitations of my test infrastructure. I ran these tests on my home  FiOS connection. My ISP offers no bandwidth guarantees, and I also used my connection for other bandwidth-intensive activities while the test was in progress. Sia would likely show higher bandwidth on an uncontested, server-grade network link.*
 
-{% include image.html file="upload-bandwidth.png" alt="Graph of upload bandwidth over time" fig_caption="Sia 1.3.1 Load Test&#58; Real Data - Upload bandwidth (file data)" img_link="true" %}
+{% include image.html file="upload-bandwidth.png" alt="Graph of upload bandwidth over time" fig_caption="Sia 1.3.1 Load Test&#58; Real Data - Upload bandwidth (file data)" img_link="true" border="true" %}
 
 **Upload bandwidth slowed exponentially with file count**.
 
@@ -251,7 +251,7 @@ All the metrics shown in this report come from three Sia daemon APIs that [sia_m
 
 The API latency is the total amount of time required to call these three APIs in sequence:
 
-{% include image.html file="api-latency.png" alt="Graph of API latency over time" fig_caption="Sia 1.3.1 Load Test&#58; Real Data - API Latency" img_link="true" %}
+{% include image.html file="api-latency.png" alt="Graph of API latency over time" fig_caption="Sia 1.3.1 Load Test&#58; Real Data - API Latency" img_link="true" border="true" %}
 
 **API latency is high**.
 

--- a/_sass/my-inline.scss
+++ b/_sass/my-inline.scss
@@ -10,3 +10,7 @@ figcaption {
   color: #898c8f;
   font-size: .75rem;
 }
+
+img.border {
+  border: 1px solid $border-color;
+}


### PR DESCRIPTION
This PR fixes #47 .

This update adds in a new ability to pass in a border parameter to the image template in order to draw a 1px solid border around an image.

For now, I coded this feature so that a writer can simple add: `border="true"` to the image include and the template will add the proper border class to the image.  In the future, if additional styles of borders are desired, then we may want to add a little more logic to also give the user the ability to pass in a specific border class.  In other words, please see the table below:

| Parameter Value        | Result           | Complete in this PR?  |
| ------------- | ------------- |:-----:|
| paramter null or not defined at all      | no border around image | Yes |
| false      | no border around image | Yes |
| true      | adds default border class for 1px solid gray border | Yes |
| specific border class (string) | adds specified border class | No, can include now or for future release if desired.  The CSS would have to exist as well for any other use-cases/styles for it to really work |

**Please NOTE:** I included 1 example of the image include with the border turned on for 1 image in the `_posts/2018-04-12-load-test-3.md` article.  I'm not sure if a border is desired on this image or not, but thought it would be good to include an example?  If you'd like me to add that parameter to ALL graph images or remove the 1 example, I can do either of those, but wanted to specifically call that example out.
