### PR TITLE
Feature: Adding tag indexes for all current tags

### DIFF
--- a/_featured_tags/ansible.md
+++ b/_featured_tags/ansible.md
@@ -1,0 +1,7 @@
+---
+layout: list
+title: Ansible
+slug: ansible
+description: >
+  Ansible Tag Index
+---

--- a/_featured_tags/api.md
+++ b/_featured_tags/api.md
@@ -1,0 +1,7 @@
+---
+layout: list
+title: API
+slug: api
+description: >
+  API Tag Index
+---

--- a/_featured_tags/automation.md
+++ b/_featured_tags/automation.md
@@ -1,0 +1,7 @@
+---
+layout: list
+title: Automation
+slug: automation
+description: >
+  Automation Tag Index
+---

--- a/_featured_tags/benchmark.md
+++ b/_featured_tags/benchmark.md
@@ -1,0 +1,7 @@
+---
+layout: list
+title: Benchmark
+slug: benchmark
+description: >
+  Benchmark Tag Index
+---

--- a/_featured_tags/blockchain.md
+++ b/_featured_tags/blockchain.md
@@ -1,0 +1,7 @@
+---
+layout: list
+title: Blockchain
+slug: blockchain
+description: >
+  Blockchain Tag Index
+---

--- a/_featured_tags/load-test.md
+++ b/_featured_tags/load-test.md
@@ -1,0 +1,7 @@
+---
+layout: list
+title: Load test
+slug: load test
+description: >
+  Load test Tag Index
+---

--- a/_featured_tags/metrics.md
+++ b/_featured_tags/metrics.md
@@ -1,0 +1,7 @@
+---
+layout: list
+title: Metrics
+slug: metrics
+description: >
+  Metrics Tag Index
+---

--- a/_featured_tags/sia.md
+++ b/_featured_tags/sia.md
@@ -1,0 +1,7 @@
+---
+layout: list
+title: Sia
+slug: sia
+description: >
+  Sia Tag Index
+---

--- a/_featured_tags/siacoin.md
+++ b/_featured_tags/siacoin.md
@@ -1,0 +1,7 @@
+---
+layout: list
+title: Siacoin
+slug: siacoin
+description: >
+  Siacoin Tag Index
+---

--- a/_featured_tags/speculation.md
+++ b/_featured_tags/speculation.md
@@ -1,0 +1,7 @@
+---
+layout: list
+title: Speculation
+slug: speculation
+description: >
+  Speculation Tag Index
+---

--- a/_featured_tags/storj.md
+++ b/_featured_tags/storj.md
@@ -1,0 +1,7 @@
+---
+layout: list
+title: Storj
+slug: storj
+description: >
+  Storj Tag Index
+---

--- a/_featured_tags/timestamps.md
+++ b/_featured_tags/timestamps.md
@@ -1,0 +1,5 @@
+---
+layout: list
+title: Timestamps
+slug: timestamps
+---


### PR DESCRIPTION
This PR fixes #36 

This update includes tag index pages for all **_current_** tags that are on the site as it exists now.

For each "tag" that exists on the site, a new "tag" markdown file needs to be created to have a index for each tag.  I think doing this for any new tag indexes should be pretty self explanatory and can copy/paste from an existing file.

A couple items to note though:
- [X] The `slug` frontmatter field in the tag index markdown files need to match the "tags" on the blog posts themselves **exactly**.  **Case matters**.
- [X] The `description` field is optional.  I did fill this in for ALL of the current tag indexes, not sure if that is desired or not?  See screenshots below of examples with and without the description on the index pages.
- [X] Tag index pages must be filed under the `_featured_tags` directory to be included in the "tag collection."

## Example Screenshots of Tag Index page
See the below screenshots of how the tag index pages look by default with the Hydejack theme.  Do these look okay or any customizations desired to look/feel/exposed blog post content?

### Example Screenshot of Tag Index page with "description" frontmatter field included
<kbd>
<img width="1303" alt="screen shot 2018-04-16 at 11 41 31 am" src="https://user-images.githubusercontent.com/2396774/38840186-6197d7de-41ac-11e8-9e5a-7f50d0e5516c.png">
</kbd>

### Example Screenshot of Tag Index page with "description" frontmatter field excluded
<kbd>
<img width="1109" alt="screen shot 2018-04-16 at 11 42 04 am" src="https://user-images.githubusercontent.com/2396774/38840193-6912309a-41ac-11e8-9259-869d9d379f7d.png">
</kbd>
