### PR TITLE
Feature: Removing need for "permalink" in blog post frontmatter

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -158,6 +158,10 @@ collections:
     permalink:         /projects/:path/
     output:            true
 
+  posts:
+    permalink:         /:title/
+    output:            true
+
 defaults:
   - scope:
       type: posts

--- a/_posts/2018-02-07-sia-load-test-preview.md
+++ b/_posts/2018-02-07-sia-load-test-preview.md
@@ -7,7 +7,6 @@ description: A rigorous test of Sia's upload capacity.
 tags:
 - sia
 - load test
-permalink: "/sia-load-test-preview/"
 ---
 
 Sia's [first blog post of 2018](https://blog.sia.tech/sia-triannual-update-september-december-2017-8afdf9c10325) made it clear that this is the year they hope to achieve enterprise adoption:

--- a/_posts/2018-02-16-sia-metrics-collector.md
+++ b/_posts/2018-02-16-sia-metrics-collector.md
@@ -7,7 +7,6 @@ tags:
 - sia
 - metrics
 - load test
-permalink: "/sia-metrics-collector/"
 ---
 
 When I initially thought of [load testing Sia](/sia-load-test-preview/), I thought I'd just watch Sia through its GUI, Sia-UI. As I started writing the test automation, I realized I wanted more insight into what Sia was doing throughout the test.

--- a/_posts/2018-02-18-new-sia-library.md
+++ b/_posts/2018-02-18-new-sia-library.md
@@ -6,7 +6,6 @@ description: A first look at a long-awaited library.
 tags:
 - sia
 - api
-permalink: "/new-sia-library/"
 ---
 
 In my last post, I described the [testing tools](/sia-metrics-collector/) I developed to load test Sia. I shared that article on [reddit](https://redd.it/7y2q3k) and lamented the fact that I had to write my tools in Python using a third-party library because Sia doesn't offer any official client libraries.

--- a/_posts/2018-02-24-sia-block-timestamps.md
+++ b/_posts/2018-02-24-sia-block-timestamps.md
@@ -6,7 +6,6 @@ description: How hard can a simple timestamp be?
 tags:
 - sia
 - timestamps
-permalink: "/sia-block-timestamps/"
 ---
 
 As I was gathering my cryptocurrency records for what promises to be an exciting tax season, I stumbled upon a Sia task that I never expected to be hard: finding a Sia block's timestamp.

--- a/_posts/2018-02-27-dont-trust-the-roadmap.md
+++ b/_posts/2018-02-27-dont-trust-the-roadmap.md
@@ -7,7 +7,6 @@ description: If you're expecting any of the 2018 Q1 features to happen, I have b
 tags:
 - sia
 - timestamps
-permalink: "/dont-trust-the-roadmap/"
 ---
 
 For the past few weeks, I've seen cryptocurrency bloggers breathlessly tell their readers about all the exciting things Sia will do in the first quarter of 2018.

--- a/_posts/2018-03-08-automating-sia-setup.md
+++ b/_posts/2018-03-08-automating-sia-setup.md
@@ -7,7 +7,6 @@ tags:
 - ansible
 - sia
 - automation
-permalink: "/automating-sia-setup/"
 ---
 
 One of the biggest headaches in using Sia is how long it takes to complete the initial setup. Unfortunately, I can't solve that problem. What I can do is make it less tedious and labor-intensive.

--- a/_posts/2018-03-15-load-test-1.md
+++ b/_posts/2018-03-15-load-test-1.md
@@ -6,7 +6,6 @@ description: How many files can Sia handle?
 tags:
 - sia
 - load test
-permalink: "/load-test-1/"
 image: "/images/2018-03-15-load-test-1/renter-spending.png"
 ---
 

--- a/_posts/2018-03-23-load-test-2.md
+++ b/_posts/2018-03-23-load-test-2.md
@@ -6,7 +6,6 @@ description: Testing Sia's performance on real-world data
 tags:
 - sia
 - load test
-permalink: "/load-test-2/"
 image: "/images/2018-03-23-load-test-2/storage-efficiency.png"
 ---
 

--- a/_posts/2018-04-01-every-siacoin-review-ever.md
+++ b/_posts/2018-04-01-every-siacoin-review-ever.md
@@ -9,7 +9,6 @@ tags:
 - sia
 - siacoin
 - speculation
-permalink: "/every-siacoin-review-ever/"
 image: "/images/2018-04-01-every-siacoin-review-ever/thumbnail.jpg"
 ---
 

--- a/_posts/2018-04-06-automating-storj-setup.md
+++ b/_posts/2018-04-06-automating-storj-setup.md
@@ -7,7 +7,6 @@ tags:
 - ansible
 - storj
 - automation
-permalink: "/automating-storj-setup/"
 ---
 
 I recently tried running Storj and was quickly confused. The [Github repo](https://github.com/Storj/storjshare-daemon) includes instructions for installing Storj on the command-line, but it never explains how to actually *run* it.

--- a/_posts/2018-04-10-performance-tuning-sia.md
+++ b/_posts/2018-04-10-performance-tuning-sia.md
@@ -7,7 +7,6 @@ tags:
 - sia
 - blockchain
 - benchmark
-permalink: "/performance-tuning-sia/"
 ---
 
 *This is a guest post by Sia community contributor [Thomas Bennett](https://github.com/tbenz9).*

--- a/_posts/2018-04-12-load-test-3.md
+++ b/_posts/2018-04-12-load-test-3.md
@@ -6,7 +6,6 @@ description: Testing Sia's maximum capacity under ideal conditions
 tags:
 - sia
 - load test
-permalink: "/load-test-3/"
 image: "/images/2018-04-12-load-test-3/storage-efficiency.png"
 ---
 


### PR DESCRIPTION
This issue fixes #62 

This change sets the default url for a blog post to the blog post's filename without the date included.  In order to implement this change, we set the "Default" permalink in the `_config.yml` file for the `posts` collection.

## Important Notes:
- [X] As part of this change, I also removed ALL of the `permalink:` frontmatter fields/values from ALL of the blog posts, except 1.
- [X] The 1 exception is the `_posts/2018-04-05-benchmarking-sia.md` blog post.  For this lone blog post, the permalink is different than the filename, so I left the `permalink:` frontmatter field in this blog post as that will always override the `_config.yml` defaults.  I didn't want to change that due to any URL change/redirect issues.  If a different action should be taken on that specific blog post, please let me know!

