### PR TITLE
Updating Jekyll from 3.7.2 to 3.8.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'jekyll', '~> 3.7.2'
+gem 'jekyll', '~> 3.8.1'
 gem 'jekyll-admin', group: :jekyll_plugins
 gem 'jekyll-paginate'
 gem 'jekyll-feed'


### PR DESCRIPTION
This PR fixes #92.

This is a very simple update to ensure the site is built with Jekyll 3.8.1 locally and for production. Version 3.8.1 is the latest stable jekyll release and has a couple bug fixes that were introduced with 3.8.0 so I went with this release as the issue was created before the bug fixes were in place.

From my perspective, I updated the version in the site's `Gemfile` and then performed some regression testing to ensure no noticeable odd behavior, which none was observed.  Build times also stayed about the same unfortunately so no significant optimizations to report on that front from what I observed.  The release definitely has some exciting features to take advantage of though!
