### PR TITLE
Feature: Adding file include capability

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -162,6 +162,14 @@ collections:
     permalink:         /:title/
     output:            true
 
+  files:
+    output: true
+    permalink: /:collection/:path:output_ext
+
+  ymls:
+    output: true
+    permalink: /files/:path.yml
+
 defaults:
   - scope:
       type: posts

--- a/_files/sia-streaming-preview/nginx.conf
+++ b/_files/sia-streaming-preview/nginx.conf
@@ -1,0 +1,18 @@
+---
+title: nginx.conf
+---
+events {}
+
+http {
+    upstream sia-backend {
+      server sia:9980;
+    }
+
+    server {
+      listen 80;
+      proxy_read_timeout 600s;
+
+      rewrite ^/(.+)$ /renter/stream/$1 last;
+      location /renter/stream/ { proxy_pass http://sia:9980; }
+    }
+}

--- a/_includes/files.html
+++ b/_includes/files.html
@@ -1,0 +1,52 @@
+{% comment %}
+<!--
+  Files Embed Include
+
+  This include file makes it possible to easily embed a file from the
+  "files" collection within a page, post, or layout. The file will be
+  displayed inside a pre block and include a download link underneath.
+
+  @param {string} "title" - the yml meta field for title in the download file
+  @param {string} "language" - the coding language used for syntax highlighting
+
+-->
+{% endcomment %}
+
+{% comment %}
+<!-- determine correct collection based on language param -->
+{% endcomment %}
+{% if include.language == "yml" or include.language == "yaml" %}
+	{% assign files = site.ymls | where: 'title', include.title %}
+{% else %}
+	{% assign files = site.files | where: 'title', include.title %}
+{% endif %}
+
+{% comment %}
+<!-- determine syntax highlighting language.  Defaults to null -->
+{% endcomment %}
+{% assign lang_highlight = "" %}
+{% if include.language %}
+	{% assign lang_highlight = include.language %}
+{% endif %}
+
+{% for file in files %}
+
+  {% comment %}
+  <!-- determine correct collection based on language param -->
+  {% endcomment %}
+  {% assign file_path = file.relative_path  | remove: '_files/'  | remove: '_ymls/' %}
+  {% if include.language == "yml" or include.language == "yaml" %}
+    {% assign file_path = file_path | append: "." | append: include.language %}
+  {% endif %}
+  {% assign link = site.baseurl | append: '/files/' | append: file_path %}
+
+```{{ lang_highlight }}
+{{ file.content -}}
+```
+{:.code-block-tab}
+
+<div class="clearfix full-width">
+  <a href="{{ link }}" download class="btn code-tab">download raw</a>
+</div>
+
+{% endfor %}

--- a/_posts/2018-05-08-sia-streaming-preview.md
+++ b/_posts/2018-05-08-sia-streaming-preview.md
@@ -33,45 +33,7 @@ You'll need to download just two files, which I'll explain in turn:
 
 ### docker-compose.yml
 
-```yaml
-services:
-  sia:
-    image: mtlynch/sia:1.3.3-rc1
-    container_name: sia
-    environment:
-      - SIA_MODULES=gctrw
-    restart: on-failure
-    ports:
-      - 9981:9981
-    volumes:
-      - ./sia-data:/sia-data
-      - ./uploads:/sia-uploads
-  nginx:
-    image: nginx
-    container_name: nginx
-    restart: always
-    ports:
-      - 80:80
-    volumes:
-      - ./nginx.conf:/etc/nginx/nginx.conf:ro
-    links:
-      - sia
-  # sia-metrics-collector is optional. It will collect Sia metrics for you
-  # in your metrics/ folder. You can delete this section if you don't want it.
-  sia-metrics-collector:
-    image: mtlynch/sia_metrics_collector:2018-05-08
-    container_name: sia-metrics-collector
-    environment:
-      - SIA_HOSTNAME=http://sia
-      - OUTPUT_FILE=/metrics/metrics.csv
-    restart: on-failure
-    volumes:
-      - ./metrics:/metrics
-    depends_on:
-      - sia
-    links:
-      - sia
-```
+{% include files.html title="docker-compose.yml" language="yml" %}
 
 This file tells Docker to set up a network of three containers to support my streaming solution.
 
@@ -83,23 +45,7 @@ Finally, there's the Sia metrics collector. That one is optional and just captur
 
 ### nginx.conf
 
-```text
-events {}
-
-http {
-    upstream sia-backend {
-      server sia:9980;
-    }
-
-    server {
-        listen 80;
-        proxy_read_timeout 600s;
-
-        rewrite ^/(.+)$ /renter/stream/$1 last;
-        location /renter/stream/ { proxy_pass http://sia:9980; }
-    }
-}
-```
+{% include files.html title="nginx.conf" language="text" %}
 
 This is the configuration file for nginx. It listens on port 80, the default port for HTTP traffic. When it receives an HTTP request for a path like `/foo/bar.mp4`, it forwards the request to the Sia node and rewrites the path to `http://sia:9980/renter/stream/foo/bar.mp4`, which is Sia's [streaming download endpoint](https://github.com/NebulousLabs/Sia/blob/master/doc/API.md#renterstreamsiapath-get).
 

--- a/_sass/my-style.scss
+++ b/_sass/my-style.scss
@@ -3,11 +3,6 @@
 @import "vendor/magnific-popup/main.scss";
 
 /* Subscribe Form Styles */
-pre {
-  width: 100%;
-  margin: 0 auto;
-}
-
 .message-newsletter {
   padding: 1rem;
 
@@ -114,4 +109,35 @@ table:not(.highlight) {
     }
   }
 
+}
+
+/* Code Block Sytles */
+pre {
+  width: 100%;
+  margin: 0 auto;
+  border-width: 1px;
+  border-style: solid;
+  border-color: #f2f3f3;
+}
+
+.code-tab {
+  border-width: 1px;
+  border-style: solid;
+  border-color: #f2f3f3;
+  border-top: 0;
+  border-radius: 0 0 4px 4px;
+  background-color: #fafafa;
+  margin-top: -2.1rem;
+  z-index: 10;
+  position: relative;
+  padding: 0.5em 1em;
+  float: right;
+  color: #268bd2;
+  font-weight: normal;
+  font-size: .75rem;
+  margin-bottom: 2rem
+}
+
+.full-width {
+  width: 100%;
 }

--- a/_ymls/sia-streaming-preview/docker-compose
+++ b/_ymls/sia-streaming-preview/docker-compose
@@ -1,0 +1,40 @@
+---
+title: docker-compose.yml
+---
+services:
+  sia:
+    image: mtlynch/sia:1.3.3-rc1
+    container_name: sia
+    environment:
+      - SIA_MODULES=gctrw
+    restart: on-failure
+    ports:
+      - 9981:9981
+    volumes:
+      - ./sia-data:/sia-data
+      - ./uploads:/sia-uploads
+  nginx:
+    image: nginx
+    container_name: nginx
+    restart: always
+    ports:
+      - 80:80
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+    links:
+      - sia
+  # sia-metrics-collector is optional. It will collect Sia metrics for you
+  # in your metrics/ folder. You can delete this section if you don't want it.
+  sia-metrics-collector:
+    image: mtlynch/sia_metrics_collector:2018-05-08
+    container_name: sia-metrics-collector
+    environment:
+      - SIA_HOSTNAME=http://sia
+      - OUTPUT_FILE=/metrics/metrics.csv
+    restart: on-failure
+    volumes:
+      - ./metrics:/metrics
+    depends_on:
+      - sia
+    links:
+      - sia


### PR DESCRIPTION
This PR fixes #100.

## Overview
This PR adds the same file include capability that exists on mtlynch.io that makes it possible to include file snippets into code blocks in article pages from include files.  In addition, the template also has a download link/tab in the lower right when using the file include feature.  I have also included the capability to include yml files as well as part of this PR as those require a different collection due to yml files being more sensitive to jekyll sites and require special handling.

## Notes
This works exactly how it does on mtlynch.io, but I did tweak the layout/styles slightly to fit the Space Duck site/theme better.

In addition, it should be noted that I did include 2 examples of using this feature in the `sia-streaming-preview` blog article:
- 1 example is for the `docker-compose.yml` file code block in this article to prove out that yml files can be included with this feature
- 2nd example is for the `nginx.conf` file code block in this article to prove out that non-yml (other) files can be included with this feature

If those examples should *NOT* be included, I can remove them.

## Screenshot of file include
<img width="1097" alt="screen shot 2018-05-20 at 12 11 53 pm" src="https://user-images.githubusercontent.com/2396774/40280843-057ce940-5c27-11e8-9a93-93c34b49cf75.png">
