### PR TITLE
Bug: Fixing mobile sidebar menu bottom spacing

### DIFF
--- a/_sass/my-inline.scss
+++ b/_sass/my-inline.scss
@@ -4,6 +4,11 @@
 .sidebar-bg {
   background-size: contain; 
   background-repeat: no-repeat;
+  background-position-y: 10%;
+
+  @media screen and (min-width: $break-point-3) {
+    background-position-y: center;
+  }
 }
 
 /* Custom Mobile Menu-bar Styles */
@@ -27,6 +32,14 @@
 
 .site-title-2 {
   color: #F9B635;
+}
+
+.sidebar-sticky {
+  bottom: 4rem;
+
+  @media screen and (min-width: $break-point-3) {
+    bottom: 1rem;
+  }
 }
 
 /* Custom Image Styles */


### PR DESCRIPTION
This PR fixes #107.

This PR attempts to fix the mobile sidebar menu spacing that was illustrated in #107.  I wasn't able to reproduce the issue in Chrome Dev tools emulator for the Pixel 2 or anything else that I tried, however, I was able to identify an even bigger spacing issue on iPhone 6 Safari after scrolling to the top and the bottom browser menu showing, so I'm 95% sure the updated spacing in this PR should remedy the problem on the Pixel 2 as well and just provide more bottom space in general for mobile device browsers.

Previously the bottom spacing was set to 1rem with the theme, this PR quadruples that to 4rem so hopefully that should be more than sufficient to ensure it isn't hidden on any mobile browsers/devices.  When pushing that spacing up it did start to bleed into the background logo, so I altered the spacing for that as well on the mobile sidebar menu.  The defaults then reset on non-mobile devices back to the theme's original spacing guidelines.

### Screenshot of iPhone 6 Safari before this PR
![img_0707](https://user-images.githubusercontent.com/2396774/40283615-16835bd4-5c4f-11e8-8349-c2f4758632c5.PNG)

### Screenshot of iPhone 6 Safari after this PR
![img_0711](https://user-images.githubusercontent.com/2396774/40283641-8a8a69a0-5c4f-11e8-80ce-5f4202438b02.PNG)

